### PR TITLE
Better automation for the publishing process

### DIFF
--- a/.github/setup.py.tmpl
+++ b/.github/setup.py.tmpl
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 setup(
     name='pyuniqid',
     packages=['pyuniqid'],
-    version='1.2',
+    version='${VERSION}',
     license='MIT',
     description='A Unique Hexatridecimal ID generator',
     long_description=long_description,
@@ -15,7 +15,7 @@ setup(
     author='Boris Skurikhin',
     author_email='boriskurikhin@gmail.com',
     url='https://github.com/boriskurikhin/pyuniqid',
-    download_url='https://test.123',
+    download_url='${DOWNLOAD_URL}',
     keywords=[
         'unique',
         'id',

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,7 +20,9 @@ jobs:
 
     - name: Get tag and version
       id: util
-      run: echo "::set-output name=version::${GITHUB_REF:11}"
+      run: |
+        echo ${GITHUB_REF}
+        echo "::set-output name=version::${GITHUB_REF:10}"
 
     - name: Edit setup.py for new release
       env:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: Upload Python Package
 
 on:
   release:
-    - created
+    types: [created]
 
 jobs:
   deploy:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,15 +22,10 @@ jobs:
       id: util
       run: echo "::set-output name=version::$(echo $GITHUB_REF | sed -e s/'refs\/tags\/[a-zA-Z]*'/''/)"
 
-    - name: Check output
-      run: |
-        echo $GITHUB_REF
-        echo ${{ steps.util.outputs.version }}
-
     - name: Edit setup.py for new release
       env:
         VERSION: ${{ steps.util.outputs.version }}
-        DOWNLOAD_URL: https://github.com/${{ github.repo }}/archive/v${{ steps.util.outputs.version }}.tar.gz
+        DOWNLOAD_URL: https://github.com/${{ github.repository }}/archive/v${{ steps.util.outputs.version }}.tar.gz
       run: envsubst < .github/setup.py.tmpl > setup.py
 
     - name: Output setup.py

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,12 +20,14 @@ jobs:
 
     - name: Get tag and version
       id: util
-      run: echo "::set-output name=version::$(echo $GITHUB_REF | sed -e s/'refs\/tags\/[a-zA-Z]*'/''/)"
+      run: |
+        echo "::set-output name=tag::${GITHUB_REF##*/}"
+        echo "::set-output name=version::$(echo $GITHUB_REF | sed -e s/'refs\/tags\/[a-zA-Z]*'/''/)"
 
     - name: Edit setup.py for new release
       env:
         VERSION: ${{ steps.util.outputs.version }}
-        DOWNLOAD_URL: https://github.com/${{ github.repository }}/archive/v${{ steps.util.outputs.version }}.tar.gz
+        DOWNLOAD_URL: https://github.com/${{ github.repository }}/archive/${{ steps.util.outputs.tag }}.tar.gz
       run: envsubst < .github/setup.py.tmpl > setup.py
 
     - name: Output setup.py

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,9 +20,12 @@ jobs:
 
     - name: Get tag and version
       id: util
+      run: echo "::set-output name=version::$(echo $GITHUB_REF | sed -e s/'refs\/tags\/[a-zA-Z]*'/''/)"
+
+    - name: Check output
       run: |
-        echo ${GITHUB_REF}
-        echo "::set-output name=version::${GITHUB_REF:10}"
+        echo $GITHUB_REF
+        echo ${{ steps.util.outputs.version }}
 
     - name: Edit setup.py for new release
       env:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,9 +1,8 @@
 name: Upload Python Package
 
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    - created
 
 jobs:
   deploy:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,4 @@
-name: Upload Python Package
+name: Continuous Delivery
 
 on:
   release:
@@ -30,18 +30,15 @@ jobs:
         DOWNLOAD_URL: https://github.com/${{ github.repository }}/archive/${{ steps.util.outputs.tag }}.tar.gz
       run: envsubst < .github/setup.py.tmpl > setup.py
 
-    - name: Output setup.py
-      run: cat setup.py
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
 
-    # - name: Install dependencies
-    #   run: |
-    #     python -m pip install --upgrade pip
-    #     pip install setuptools wheel twine
-
-    # - name: Build and publish
-    #   env:
-    #     TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-    #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-    #   run: |
-    #     python setup.py sdist bdist_wheel
-    #     twine upload dist/*
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,8 +1,9 @@
 name: Upload Python Package
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - "v*"
 
 jobs:
   deploy:
@@ -18,15 +19,28 @@ jobs:
       with:
         python-version: '3.x'
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-        
-    - name: Build and publish
+    - name: Get tag and version
+      id: util
+      run: echo "::set-output name=version::${GITHUB_REF:11}"
+
+    - name: Edit setup.py for new release
       env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+        VERSION: ${{ steps.util.outputs.version }}
+        DOWNLOAD_URL: https://github.com/${{ github.repo }}/archive/v${{ steps.util.outputs.version }}.tar.gz
+      run: envsubst < .github/setup.py.tmpl > setup.py
+
+    - name: Output setup.py
+      run: cat setup.py
+
+    # - name: Install dependencies
+    #   run: |
+    #     python -m pip install --upgrade pip
+    #     pip install setuptools wheel twine
+
+    # - name: Build and publish
+    #   env:
+    #     TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+    #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+    #   run: |
+    #     python setup.py sdist bdist_wheel
+    #     twine upload dist/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Python package
+name: Continuous Integration
 
 on: push
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     author='Boris Skurikhin',
     author_email='boriskurikhin@gmail.com',
     url='https://github.com/boriskurikhin/pyuniqid',
-    download_url='https://test.123',
+    download_url='https://github.com/boriskurikhin/pyuniqid/archive/v1.2.tar.gz',  # noqa
     keywords=[
         'unique',
         'id',


### PR DESCRIPTION
### What's been done?

So I've made some changes to the CD workflow to better automate the process of publishing the package to PyPi. There's one kink that you might not be a fan of, so there's an alternate workaround if you would like (it'll just need more regex).

There's a step to parse out a version number and the tag from a tag ref. It would take something like this:

```
refs/tags/v1.23.4
```

and turns it into, effectively this:

```
# version
1.23.4
# tag
v1.23.4
```

It then uses those values, and runs `envsubst` on a template setup.py (`.github/setup.py.tmpl`). This template setup.py has a couple tokens in it, namely `VERSION` and `DOWNLOAD_URL`, where the values will be punched in. The resulting file overwrites `setup.py` (just on the worker, doesn't commit changes to repo). This way, the `setup.py` is up-to-date with the latest version, taken straight from the tag version, and the appropriate download URL, put together using the tag. The worker can then continue by publishing the package to PyPi, of course using the newly put together `setup.py`.

### How does this affect the development process?

Not much. You no longer have to worry about the `setup.py` at all really, in fact it could be deleted if you wanted. When the CD tool runs `envsubst` it will generate the `setup.py` file from the template `setup.py.tmpl` file. If in development you would like to make changes to, say, the keywords or classifiers, you would need to do that in `.github/setup.py.tmpl`, **not** `setup.py`.

You make your code changes, create a tag as you normally would...

```bash
$ git tag v1.2 && git push origin v1.2
```

Then on GitHub you need to make a release for that tag, in order to trigger the workflow...

<img width="1220" alt="Screen Shot 2020-06-29 at 00 13 14" src="https://user-images.githubusercontent.com/31599272/85972782-deabe500-b99e-11ea-9734-decf1782bbb9.png">

Add any metadata you would like...

<img width="929" alt="Screen Shot 2020-06-29 at 00 25 34" src="https://user-images.githubusercontent.com/31599272/85972877-1ca90900-b99f-11ea-8ac2-8d7292fab305.png">

Publish the release, and the workflow will start! It will automatically modify/generate an up-to-date `setup.py`, and publish!

### Disclaimer

I've run this *in theory* without actually publishing... I just had the worker spit out the contents of the generated `setup.py` and it looked something like this [for a fictitious tagged release: `v1.9`](https://github.com/matootie/pyuniqid/runs/817200177?check_suite_focus=true#step:6:1). Judging by that, I figure it would work exactly how you would expect.
